### PR TITLE
feat(store): centralize mutations in typed, validated actions

### DIFF
--- a/e2e/vue.spec.ts
+++ b/e2e/vue.spec.ts
@@ -6,3 +6,30 @@ test('visits the app root url', async ({ page }) => {
   await page.goto('/');
   await expect(page.locator('div#app header h1')).toHaveText('Marcador de Canastra');
 })
+
+test('user can start a game and add a round', async ({ page }) => {
+  await page.goto('/');
+
+  // Step 1: choose 2 teams
+  await page.getByText('2 Equipes').click();
+  // Step 2: names are pre-filled; proceed
+  await page.getByRole('button', { name: 'Próximo' }).click();
+  // Step 3: winning points; proceed
+  await page.getByRole('button', { name: 'Próximo' }).click();
+  // Step 4: obrigação; start the game
+  await page.getByRole('button', { name: 'Iniciar Jogo' }).click();
+
+  // Open the score sheet from the FAB menu
+  await page.getByRole('button', { name: '+' }).click();
+  await page.getByRole('button', { name: 'Adicionar Pontos' }).click();
+
+  // Fill the two score inputs and submit
+  const inputs = page.locator('input[type="number"]');
+  await inputs.nth(0).fill('100');
+  await inputs.nth(1).fill('200');
+  await page.getByRole('button', { name: 'Adicionar Pontos' }).click();
+
+  // Round history should reflect the added round
+  await expect(page.getByText('1 rodada')).toBeVisible();
+});
+

--- a/e2e/vue.spec.ts
+++ b/e2e/vue.spec.ts
@@ -12,6 +12,8 @@ test('user can start a game and add a round', async ({ page }) => {
 
   // Step 1: choose 2 teams
   await page.getByText('2 Equipes').click();
+  // Confirm the team-selection transition completed
+  await expect(page.getByRole('heading', { name: 'Nomes das Equipes' })).toBeVisible();
   // Step 2: names are pre-filled; proceed
   await page.getByRole('button', { name: 'Próximo' }).click();
   // Step 3: winning points; proceed

--- a/src/components/AddMatchButton.vue
+++ b/src/components/AddMatchButton.vue
@@ -126,7 +126,7 @@ const closeDeleteModal = () => {
 }
 
 const addScore = (scores: number[]) => {
-  store.addScore(scores)
+  store.addRound(scores)
   closeScoreSheet()
 }
 

--- a/src/components/AddTeams.vue
+++ b/src/components/AddTeams.vue
@@ -258,10 +258,12 @@ const nextStep = () => {
 
   if (currentStep.value === totalSteps) {
     // Start game
-    store.teams = selectedTeams.value
-    store.names = teamNames.value.slice(0, selectedTeams.value)
-    store.winningPoints = winningPoints.value
-    store.obrigacaoPoints = obrigacaoPoints.value
+    store.startGame({
+      teams: selectedTeams.value,
+      names: teamNames.value.slice(0, selectedTeams.value),
+      winningPoints: winningPoints.value,
+      obrigacaoPoints: obrigacaoPoints.value,
+    })
     return
   }
 

--- a/src/components/ListMatches.vue
+++ b/src/components/ListMatches.vue
@@ -85,7 +85,7 @@ const confirmDelete = (index: number) => {
 
 const deleteRound = () => {
   if (deleteIndex.value !== null) {
-    store.removeScore(deleteIndex.value)
+    store.removeRound(deleteIndex.value)
     deleteIndex.value = null
   }
 }

--- a/src/components/ScoreInputForm.vue
+++ b/src/components/ScoreInputForm.vue
@@ -67,16 +67,19 @@ const emit = defineEmits<{
 }>()
 
 // Form state
-const scores = ref<number[]>(new Array(store.teams).fill(0))
+const scores = ref<(number | null)[]>(new Array(store.teams).fill(null))
 const focusedInput = ref(-1)
 
 // Computed properties
 const totalScore = computed(() => {
-  return scores.value.reduce((sum, score) => sum + (score || 0), 0)
+  return scores.value.reduce<number>(
+    (sum, score) => sum + (Number.isFinite(score) ? score! : 0),
+    0,
+  )
 })
 
 const canSubmit = computed(() => {
-  return scores.value.some((score) => score !== 0)
+  return scores.value.length === store.teams && scores.value.every((score) => Number.isFinite(score))
 })
 
 const totalClass = computed(() => {
@@ -98,9 +101,10 @@ const getInputClass = (index: number) => {
 
 const submitScore = () => {
   if (canSubmit.value) {
-    emit('submit', [...scores.value])
+    const normalized = scores.value.map((score) => (Number.isFinite(score) ? score! : 0))
+    emit('submit', normalized)
     // Reset form
-    scores.value = new Array(store.teams).fill(0)
+    scores.value = new Array(store.teams).fill(null)
   }
 }
 </script>

--- a/src/components/__tests__/ScoreInputForm.spec.ts
+++ b/src/components/__tests__/ScoreInputForm.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import ScoreInputForm from '@/components/ScoreInputForm.vue'
+import { useCanastraStore } from '@/stores/canastra'
+
+describe('ScoreInputForm', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    const store = useCanastraStore()
+    store.startGame({
+      teams: 2,
+      names: ['Nós', 'Eles'],
+      winningPoints: 3000,
+      obrigacaoPoints: 1500,
+    })
+  })
+
+  it('disables submit while any field is empty', () => {
+    const wrapper = mount(ScoreInputForm)
+    const submit = wrapper.find('button')
+    expect((submit.element as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('enables submit and emits normalized scores when all fields are valid', async () => {
+    const wrapper = mount(ScoreInputForm)
+    const inputs = wrapper.findAll('input')
+    await inputs[0].setValue(100)
+    await inputs[1].setValue(-50)
+
+    const submit = wrapper.find('button')
+    expect((submit.element as HTMLButtonElement).disabled).toBe(false)
+
+    await submit.trigger('click')
+
+    expect(wrapper.emitted('submit')).toBeTruthy()
+    expect(wrapper.emitted('submit')![0]).toEqual([[100, -50]])
+  })
+
+  it('keeps submit disabled when a field is left non-finite', async () => {
+    const wrapper = mount(ScoreInputForm)
+    const inputs = wrapper.findAll('input')
+    await inputs[0].setValue(100)
+    // inputs[1] left empty -> non-finite
+
+    const submit = wrapper.find('button')
+    expect((submit.element as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/src/stores/__tests__/canastra.spec.ts
+++ b/src/stores/__tests__/canastra.spec.ts
@@ -105,6 +105,15 @@ describe('canastra store', () => {
     })
   })
 
+  describe('addRound before startGame', () => {
+    it('rejects an empty round when no game has started', () => {
+      const store = useCanastraStore()
+      store.reset()
+      expect(() => store.addRound([])).toThrow(InvalidRoundError)
+      expect(store.rounds).toEqual([])
+    })
+  })
+
   describe('removeRound', () => {
     beforeEach(() => {
       const store = useCanastraStore()

--- a/src/stores/__tests__/canastra.spec.ts
+++ b/src/stores/__tests__/canastra.spec.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import {
+  useCanastraStore,
+  InvalidGameConfigError,
+  InvalidRoundError,
+  InvalidRoundIndexError,
+} from '@/stores/canastra'
+
+const validConfig = {
+  teams: 2,
+  names: ['Nós', 'Eles'],
+  winningPoints: 3000,
+  obrigacaoPoints: 1500,
+}
+
+describe('canastra store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('has default state', () => {
+    const store = useCanastraStore()
+    expect(store.teams).toBe(0)
+    expect(store.rounds).toEqual([])
+    expect(store.winningPoints).toBe(3000)
+    expect(store.obrigacaoPoints).toBe(1500)
+  })
+
+  describe('startGame', () => {
+    it('sets state for a valid config', () => {
+      const store = useCanastraStore()
+      store.startGame({ ...validConfig })
+      expect(store.teams).toBe(2)
+      expect(store.names).toEqual(['Nós', 'Eles'])
+      expect(store.winningPoints).toBe(3000)
+      expect(store.obrigacaoPoints).toBe(1500)
+    })
+
+    it('throws when teams is out of range', () => {
+      const store = useCanastraStore()
+      expect(() =>
+        store.startGame({ ...validConfig, teams: 4, names: ['A', 'B', 'C', 'D'] }),
+      ).toThrow(InvalidGameConfigError)
+    })
+
+    it('throws when names length does not match teams', () => {
+      const store = useCanastraStore()
+      expect(() => store.startGame({ ...validConfig, names: ['A'] })).toThrow(
+        InvalidGameConfigError,
+      )
+    })
+
+    it('throws when a name is empty', () => {
+      const store = useCanastraStore()
+      expect(() => store.startGame({ ...validConfig, names: ['A', '  '] })).toThrow(
+        InvalidGameConfigError,
+      )
+    })
+
+    it('throws when obrigacaoPoints exceeds winningPoints', () => {
+      const store = useCanastraStore()
+      expect(() =>
+        store.startGame({ ...validConfig, winningPoints: 1000, obrigacaoPoints: 1500 }),
+      ).toThrow(InvalidGameConfigError)
+    })
+
+    it('throws when winningPoints is below the minimum', () => {
+      const store = useCanastraStore()
+      expect(() =>
+        store.startGame({ ...validConfig, winningPoints: 50, obrigacaoPoints: 10 }),
+      ).toThrow(InvalidGameConfigError)
+    })
+  })
+
+  describe('addRound', () => {
+    beforeEach(() => {
+      const store = useCanastraStore()
+      store.startGame({ ...validConfig })
+    })
+
+    it('pushes a valid round and updates totals', () => {
+      const store = useCanastraStore()
+      store.addRound([100, -50])
+      expect(store.rounds).toEqual([[100, -50]])
+      expect(store.totals).toEqual([100, -50])
+    })
+
+    it('rejects NaN input and leaves rounds unchanged', () => {
+      const store = useCanastraStore()
+      expect(() => store.addRound([NaN, 10])).toThrow(InvalidRoundError)
+      expect(store.rounds).toEqual([])
+    })
+
+    it('rejects Infinity input and leaves rounds unchanged', () => {
+      const store = useCanastraStore()
+      expect(() => store.addRound([Infinity, 10])).toThrow(InvalidRoundError)
+      expect(store.rounds).toEqual([])
+    })
+
+    it('rejects a wrong team count and leaves rounds unchanged', () => {
+      const store = useCanastraStore()
+      expect(() => store.addRound([10])).toThrow(InvalidRoundError)
+      expect(store.rounds).toEqual([])
+    })
+  })
+
+  describe('removeRound', () => {
+    beforeEach(() => {
+      const store = useCanastraStore()
+      store.startGame({ ...validConfig })
+      store.addRound([10, 20])
+      store.addRound([5, 5])
+    })
+
+    it('removes a valid index', () => {
+      const store = useCanastraStore()
+      store.removeRound(0)
+      expect(store.rounds).toEqual([[5, 5]])
+    })
+
+    it('throws for a negative index and leaves rounds unchanged', () => {
+      const store = useCanastraStore()
+      expect(() => store.removeRound(-1)).toThrow(InvalidRoundIndexError)
+      expect(store.rounds.length).toBe(2)
+    })
+
+    it('throws for an out-of-range index and leaves rounds unchanged', () => {
+      const store = useCanastraStore()
+      expect(() => store.removeRound(5)).toThrow(InvalidRoundIndexError)
+      expect(store.rounds.length).toBe(2)
+    })
+  })
+
+  describe('revanche and reset', () => {
+    it('revanche clears rounds but keeps the game configuration', () => {
+      const store = useCanastraStore()
+      store.startGame({ ...validConfig })
+      store.addRound([10, 20])
+      store.revanche()
+      expect(store.rounds).toEqual([])
+      expect(store.teams).toBe(2)
+    })
+
+    it('reset returns the store to its defaults', () => {
+      const store = useCanastraStore()
+      store.startGame({ teams: 3, names: ['A', 'B', 'C'], winningPoints: 2500, obrigacaoPoints: 1000 })
+      store.reset()
+      expect(store.teams).toBe(0)
+      expect(store.winningPoints).toBe(3000)
+      expect(store.obrigacaoPoints).toBe(1500)
+    })
+  })
+})

--- a/src/stores/canastra.ts
+++ b/src/stores/canastra.ts
@@ -1,6 +1,34 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 
+export interface GameConfig {
+  teams: number
+  names: string[]
+  winningPoints: number
+  obrigacaoPoints: number
+}
+
+export class InvalidGameConfigError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidGameConfigError'
+  }
+}
+
+export class InvalidRoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidRoundError'
+  }
+}
+
+export class InvalidRoundIndexError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidRoundIndexError'
+  }
+}
+
 export const useCanastraStore = defineStore(
   'scores',
   () => {
@@ -36,16 +64,50 @@ export const useCanastraStore = defineStore(
       rounds.value = []
     }
 
-    function addScore(scores: number[]) {
-      if (!scores || scores.length !== teams.value) {
-        console.error('Scores provided do not match teams playing')
-        return
+    function startGame(config: GameConfig) {
+      if (!Number.isInteger(config.teams) || config.teams < 2 || config.teams > 3) {
+        throw new InvalidGameConfigError('Teams must be an integer between 2 and 3')
       }
-      rounds.value.push(scores)
+      if (!Array.isArray(config.names) || config.names.length !== config.teams) {
+        throw new InvalidGameConfigError('Names length must match the number of teams')
+      }
+      if (!config.names.every((name) => typeof name === 'string' && name.trim().length > 0)) {
+        throw new InvalidGameConfigError('Every team name must be a non-empty string')
+      }
+      if (!Number.isFinite(config.winningPoints) || config.winningPoints < 100) {
+        throw new InvalidGameConfigError('Winning points must be a finite number >= 100')
+      }
+      if (
+        !Number.isFinite(config.obrigacaoPoints) ||
+        config.obrigacaoPoints <= 0 ||
+        config.obrigacaoPoints > config.winningPoints
+      ) {
+        throw new InvalidGameConfigError(
+          'Obrigação points must be finite, greater than 0 and not above winning points',
+        )
+      }
+
+      teams.value = config.teams
+      names.value = [...config.names]
+      winningPoints.value = config.winningPoints
+      obrigacaoPoints.value = config.obrigacaoPoints
     }
 
-    function removeScore(row: number) {
-      rounds.value.splice(row, 1)
+    function addRound(scores: number[]) {
+      if (!Array.isArray(scores) || scores.length !== teams.value) {
+        throw new InvalidRoundError('Scores length must match the number of teams')
+      }
+      if (!scores.every((score) => Number.isFinite(score))) {
+        throw new InvalidRoundError('Every score must be a finite number')
+      }
+      rounds.value.push([...scores])
+    }
+
+    function removeRound(index: number) {
+      if (!Number.isInteger(index) || index < 0 || index >= rounds.value.length) {
+        throw new InvalidRoundIndexError('Round index is out of range')
+      }
+      rounds.value.splice(index, 1)
     }
 
     return {
@@ -57,8 +119,9 @@ export const useCanastraStore = defineStore(
       totals,
       reset,
       revanche,
-      addScore,
-      removeScore,
+      startGame,
+      addRound,
+      removeRound,
     }
   },
   {

--- a/src/stores/canastra.ts
+++ b/src/stores/canastra.ts
@@ -94,6 +94,9 @@ export const useCanastraStore = defineStore(
     }
 
     function addRound(scores: number[]) {
+      if (teams.value < 2 || teams.value > 3) {
+        throw new InvalidRoundError('A valid two- or three-team game must be started first')
+      }
       if (!Array.isArray(scores) || scores.length !== teams.value) {
         throw new InvalidRoundError('Scores length must match the number of teams')
       }


### PR DESCRIPTION
All state transitions now go through store actions that validate domain
invariants at the boundary, replacing direct component state assignments
and silent `console.error` calls.

- Add `startGame(config)` to type game setup and reject bad team counts
  (restricted to 2–3), non-empty names, and threshold ordering
  (`obrigacaoPoints > 0 && <= winningPoints`).
- Rename `addScore`/`removeScore` to `addRound`/`removeRound` with
  length, finiteness, and index guards. Invalid input throws
  `InvalidGameConfigError`, `InvalidRoundError`, or
  `InvalidRoundIndexError` instead of persisting malformed data.
- Model `ScoreInputForm` scores as `number | null` and disable submit
  until every field is finite; normalize to finite numbers (default 0)
  on submit.

AddTeams no longer assigns `store.x` directly; all mutations flow through
the store so persisted state stays well-formed.

Closes #570

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a more structured game setup flow for selecting teams, names, and scoring thresholds.
  - Added round-based score tracking, including adding and removing rounds from match history.

- **Bug Fixes**
  - Score entry now prevents submission when fields are empty or invalid.
  - Invalid game configurations and round operations are rejected with clear validation handling.
  - Submitted scores are normalized consistently, including empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->